### PR TITLE
v1.1.0 updated & added riak node configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,15 @@ The Riak connector can be configured much like any other Loopback connector usin
       "riak3.local.foo.com:8087",
       "riak4.local.foo.com:8087",
       "riak5.local.foo.com:8087"
-    ]
+    ],
+    "node_config" : {           //optional riak node config
+      "maxConnections": 128,
+      "minConnections": 1,
+      "idleTimeout": 10000,
+      "connectionTimeout": 3000,
+      "requestTimeout": 5000,
+      "cork": true
+    }
   }
 }
 ```
@@ -65,6 +73,7 @@ Your Loopback models can provide some Riak-specific configuration options.  Here
 
 ## Release notes
 
+* 1.1.0 Added additional node config params to data source & updated dependency packages.
 * 1.0.0 Currently in production over at Dittach. Tests are passing.
 * 0.1.x Improvements to test coverage, feature support, Node v0.12+ support.
 * 0.0.x Proof-of-concept releases

--- a/lib/api/all.js
+++ b/lib/api/all.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var _                   = require('lodash');
-var async               = require('async');
+var async = require('neo-async');
 var searchAndMapResults = require('./search_and_map_results');
 var bucketNameComposer  = require('../private/bucket_name_composer');
 var conditionsToIds     = require('../private/conditions_to_ids');
@@ -79,7 +79,7 @@ module.exports = function(modelName, conditions, apiCallback){
     // loopback's hand
     if (!findByIds) return callback(null, results);
 
-    var resultsById = _.indexBy(results, "id");
+      var resultsById = _.keyBy(results, "id");
     callback(null, _.map(findByIds, function (i){ return resultsById[i]; }));
   }
 

--- a/lib/api/connect.js
+++ b/lib/api/connect.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var Riak = require('basho-riak-client');
+var deepExtend = require('deep-extend');
+
 
 /**
 * Connect to Riak
@@ -15,21 +17,41 @@ var Riak = require('basho-riak-client');
 */
 module.exports = function(apiCallback){
   var self = this;
-
   if (!Array.isArray(this.settings.host)) this.settings.host = [ this.settings.host ];
+    var nodes = [];
 
-  this.db = new Riak.Client(this.settings.host);
-  this._models = this._models || {};
+    this.settings.node_config = this.settings.node_config || {};
 
-  if (!apiCallback) return;
+    var defaultNodeConfig = {
+        "maxConnections": 128,
+        "minConnections": 1,
+        "idleTimeout": 10000,
+        "connectionTimeout": 3000,
+        "requestTimeout": 5000,
+        "cork": true
+    };
 
-  this.ping(function(error, response){
-    if (error)         onConnectionFailure(error);
-    else if (response) onConnectionSuccess();
-    else               onUnexpectedError();
+    deepExtend(this.settings.node_config, defaultNodeConfig);
 
-    apiCallback(error, self.db);
-  });
+    for (var i = 0; i < this.settings.host.length; i++) {
+        var nodeConfig = this.settings.node_config;
+        nodeConfig.remoteAddress = this.settings.host[i];
+        nodes.push(new Riak.Node(nodeConfig));
+    }
+
+    var cluster = new Riak.Cluster({
+        nodes: nodes
+    });
+
+    this._models = this._models || {};
+    this.db = new Riak.Client(cluster, function (err, client) {
+        if (err) onConnectionFailure(err);
+        else if (client) onConnectionSuccess();
+        else onUnexpectedError();
+
+        apiCallback(err, self.db);
+    });
+
 
   function onConnectionSuccess(){
     self._logger('connection is established to host:', self.settings.host);

--- a/lib/api/create.js
+++ b/lib/api/create.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var async              = require('async');
-var uuid               = require('node-uuid');
+var async = require('neo-async');
+var uuid = require('uuid');
 var bucketNameComposer = require('../private/bucket_name_composer');
 
 /**

--- a/lib/api/destroy_all.js
+++ b/lib/api/destroy_all.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var async               = require('async');
+var async = require('neo-async');
 var searchAndMapResults = require('./search_and_map_results');
 var bucketNameComposer  = require('../private/bucket_name_composer');
 var conditionsToIds     = require('../private/conditions_to_ids');

--- a/lib/api/search_and_map_results.js
+++ b/lib/api/search_and_map_results.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var async              = require('async');
+var async = require('neo-async');
 var bucketNameComposer = require('../private/bucket_name_composer');
 
 module.exports = function(bucketName, conditions, mapIterator, apiCallback){

--- a/lib/api/update_all.js
+++ b/lib/api/update_all.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var async               = require('async');
+var async = require('neo-async');
 var searchAndMapResults = require('./search_and_map_results');
 var bucketNameComposer  = require('../private/bucket_name_composer');
 var conditionsToIds     = require('../private/conditions_to_ids');

--- a/lib/api/update_attributes.js
+++ b/lib/api/update_attributes.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var async              = require('async');
+var async = require('neo-async');
 var extend             = require('util')._extend;
 var bucketNameComposer = require('../private/bucket_name_composer');
 

--- a/lib/api/update_or_create.js
+++ b/lib/api/update_or_create.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var async = require('async');
+var async = require('neo-async');
 
 /**
  * Update if the model instance exists with the same id or create a new instance

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopback-connector-riak",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "LoopBack Riak Connector",
   "keywords": [
     "StrongLoop",
@@ -14,16 +14,15 @@
     "test": "mocha --timeout 60000"
   },
   "dependencies": {
-    "bluebird": "~2.9.10",
+    "basho-riak-client": "~2.4.0",
+    "bluebird": "~3.5.1",
+    "deep-extend": "~0.5.0",
+    "lodash": "~4.17.4",
     "loopback-connector": "1.x",
-    "basho-riak-client": "*",
-    "deep-extend": "~0.3.2",
-    "node-uuid": "~1.4.2",
-    "async": "~0.9.0",
-    "lodash": "~3.10.1"
+    "neo-async": "^2.5.0",
+    "uuid": "^3.1.0"
   },
   "devDependencies": {
-    "async": "~0.9.0",
     "loopback-datasource-juggler": "~2.16.0",
     "mocha": "~1.20.1",
     "rc": "~0.5.5",
@@ -34,8 +33,5 @@
     "type": "git",
     "url": "https://github.com/dittach/loopback-connector-riak"
   },
-  "license": {
-    "name": "MIT",
-    "url": ""
-  }
+  "license": "MIT"
 }

--- a/test/init.js
+++ b/test/init.js
@@ -1,4 +1,4 @@
-var async = require('async');
+var async = require('neo-async');
 var fs = require('fs');
 
 module.exports = require('should');


### PR DESCRIPTION
-added configuration options for riak nodes in datasource file
-updated packages
  - swap async for neo-async (faster lib)
  - swap node-uuid for uuid (node-uuid DEPRECATED)
  - update packages
    -bluebird@3.5.1
    -deep-extend@0.5.0
    -lodash@4.17.4 (indexBy was renamed to keyBy in v4.0.0)